### PR TITLE
Edit note action

### DIFF
--- a/app/src/main/java/com/example/cactusnotes/api/NotesApi.kt
+++ b/app/src/main/java/com/example/cactusnotes/api/NotesApi.kt
@@ -7,9 +7,7 @@ import com.example.cactusnotes.notes.data.NoteResponse
 import com.example.cactusnotes.signup.data.RegisterRequest
 import com.example.cactusnotes.signup.data.RegisterResponse
 import retrofit2.Call
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
+import retrofit2.http.*
 
 interface NotesApi {
     @POST("/auth/local/register")
@@ -23,4 +21,10 @@ interface NotesApi {
 
     @POST("/notes")
     fun createNote(@Body createNoteRequest: NoteRequest): Call<NoteResponse>
+
+    @PUT("/notes/{noteId}")
+    fun editNote(
+        @Body editNoteRequest: NoteRequest,
+        @Path("noteId") noteId: Int
+    ): Call<NoteResponse>
 }

--- a/app/src/main/java/com/example/cactusnotes/notes/EditNoteActivity.kt
+++ b/app/src/main/java/com/example/cactusnotes/notes/EditNoteActivity.kt
@@ -37,6 +37,16 @@ class EditNoteActivity : AppCompatActivity() {
         binding.content.addTextChangedListener {
             onTextChanged()
         }
+
+        val noteFromIntent: Note? = intent.getSerializableExtra("note") as Note?
+
+        if (noteFromIntent != null) {
+            noteState = CREATED
+            note = noteFromIntent.toNoteResponse()
+
+            binding.title.setText(note!!.title)
+            binding.content.setText(note!!.content)
+        }
     }
 
     private fun onTextChanged() {
@@ -63,6 +73,8 @@ class EditNoteActivity : AppCompatActivity() {
     }
 
     private fun sendEditNoteRequest(request: NoteRequest) {
+        setResult(RESULT_OK)
+
         val title = binding.title.text.toString()
         val content = binding.content.text.toString()
 
@@ -126,3 +138,9 @@ class EditNoteActivity : AppCompatActivity() {
         CREATED
     }
 }
+
+private fun Note.toNoteResponse() = NoteResponse(
+    id = id,
+    title = title,
+    content = content
+)

--- a/app/src/main/java/com/example/cactusnotes/notes/Note.kt
+++ b/app/src/main/java/com/example/cactusnotes/notes/Note.kt
@@ -1,6 +1,9 @@
 package com.example.cactusnotes.notes
 
+import java.io.Serializable
+
 data class Note(
+    val id: Int,
     val title: String,
     val content: String
-)
+) : Serializable

--- a/app/src/main/java/com/example/cactusnotes/notes/NotesAdapter.kt
+++ b/app/src/main/java/com/example/cactusnotes/notes/NotesAdapter.kt
@@ -5,7 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.cactusnotes.R
 
-class NotesAdapter : RecyclerView.Adapter<NotesHolder>() {
+class NotesAdapter(val noteClickListener: (Note) -> Unit) : RecyclerView.Adapter<NotesHolder>() {
     private var notes: List<Note> = listOf()
 
     fun submitList(noteList: List<Note>) {
@@ -20,9 +20,13 @@ class NotesAdapter : RecyclerView.Adapter<NotesHolder>() {
     }
 
     override fun onBindViewHolder(holder: NotesHolder, position: Int) {
-        val n = notes[position]
-        holder.titleText.text = n.title
-        holder.contentText.text = n.content
+        val note = notes[position]
+        holder.titleText.text = note.title
+        holder.contentText.text = note.content
+
+        holder.itemView.setOnClickListener {
+            noteClickListener(note)
+        }
     }
 
     override fun getItemCount() = notes.size

--- a/app/src/main/java/com/example/cactusnotes/notes/NotesListActivity.kt
+++ b/app/src/main/java/com/example/cactusnotes/notes/NotesListActivity.kt
@@ -26,7 +26,7 @@ class NotesListActivity : AppCompatActivity() {
 
     lateinit var binding: ActivityNotesListBinding
 
-    private val notesAdapter = NotesAdapter()
+    private val notesAdapter = NotesAdapter(::onNoteClick)
 
     private val startForResult =
         registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
@@ -51,6 +51,12 @@ class NotesListActivity : AppCompatActivity() {
             val intent = Intent(this, EditNoteActivity::class.java)
             startForResult.launch(intent)
         }
+    }
+
+    private fun onNoteClick(note: Note) {
+        val intent = Intent(this, EditNoteActivity::class.java)
+        intent.putExtra("note", note)
+        startForResult.launch(intent)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -96,7 +102,11 @@ class NotesListActivity : AppCompatActivity() {
     }
 
     private fun List<NoteResponse>.mapToNotes() = map {
-        Note(it.title, it.content)
+        Note(
+            id = it.id,
+            title = it.title,
+            content = it.content
+        )
     }
 
     private fun logOut() {


### PR DESCRIPTION
- Adds click listener to the note items so that clicking on them navigates user to the Edit Note Screen.
- Fills the Note card with text when coming with a note payload (so that it should not trigger a create note request)
- Any change to the title or the content triggers an edit note request after 300ms if not interrupted with another change event.