### PR TITLE
Implement delete note action.

### DIFF
--- a/app/src/main/java/com/example/cactusnotes/api/NotesApi.kt
+++ b/app/src/main/java/com/example/cactusnotes/api/NotesApi.kt
@@ -27,4 +27,8 @@ interface NotesApi {
         @Body editNoteRequest: NoteRequest,
         @Path("noteId") noteId: Int
     ): Call<NoteResponse>
+
+    @DELETE("/notes/{noteId}")
+    fun deleteNote(@Path("noteId") noteId: Int): Call<NoteResponse>
+
 }

--- a/app/src/main/java/com/example/cactusnotes/notes/EditNoteActivity.kt
+++ b/app/src/main/java/com/example/cactusnotes/notes/EditNoteActivity.kt
@@ -3,6 +3,9 @@ package com.example.cactusnotes.notes
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.Menu
+import android.view.MenuItem
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
 import com.example.cactusnotes.R
@@ -11,6 +14,7 @@ import com.example.cactusnotes.databinding.ActivityEditNoteBinding
 import com.example.cactusnotes.notes.EditNoteActivity.NoteState.*
 import com.example.cactusnotes.notes.data.NoteRequest
 import com.example.cactusnotes.notes.data.NoteResponse
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import retrofit2.Call
 import retrofit2.Callback
@@ -132,15 +136,59 @@ class EditNoteActivity : AppCompatActivity() {
         })
     }
 
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.edit_note_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        R.id.delete -> {
+            showDeleteDialog()
+            true
+        }
+        else -> super.onOptionsItemSelected(item)
+    }
+
+    private fun showDeleteDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setMessage(R.string.this_action_is_irreversible)
+            .setNegativeButton(R.string.cancel) { _, _ -> }
+            .setPositiveButton(R.string.delete) { _, _ ->
+                sendDeleteNoteRequest()
+            }
+            .show()
+    }
+
+    private fun sendDeleteNoteRequest() {
+        api.deleteNote(note!!.id).enqueue(object : Callback<NoteResponse> {
+            override fun onResponse(call: Call<NoteResponse>, response: Response<NoteResponse>) {
+                val noteTitle = response.body()!!.title
+                val message = getString(R.string.your_note_is_deleted, noteTitle)
+                Toast.makeText(this@EditNoteActivity, message, Toast.LENGTH_LONG).show()
+
+                setResult(RESULT_OK)
+                finish()
+            }
+
+            override fun onFailure(call: Call<NoteResponse>, t: Throwable) {
+                Snackbar.make(
+                    binding.root,
+                    R.string.couldnt_connect_to_servers,
+                    Snackbar.LENGTH_LONG
+                ).show()
+            }
+        })
+    }
+
     enum class NoteState {
         NOT_CREATED,
         IS_CREATING,
         CREATED
     }
-}
 
-private fun Note.toNoteResponse() = NoteResponse(
-    id = id,
-    title = title,
-    content = content
-)
+    private fun Note.toNoteResponse() = NoteResponse(
+        id = id,
+        title = title,
+        content = content
+    )
+}

--- a/app/src/main/res/menu/edit_note_menu.xml
+++ b/app/src/main/res/menu/edit_note_menu.xml
@@ -2,11 +2,13 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/share_button"
+        android:title="@string/share"
+        android:id="@+id/share"
         android:icon="@drawable/ic_share"
         app:showAsAction="always" />
     <item
-        android:id="@+id/delete_button"
+        android:title="@string/delete"
+        android:id="@+id/delete"
         android:icon="@drawable/ic_delete"
         app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,7 @@
     <string name="empty_note">Write something...</string>
     <string name="cancel">CANCEL</string>
     <string name="delete">DELETE</string>
+    <string name="share">Share</string>
+    <string name="this_action_is_irreversible">This action is irreversable. Are you sure you want to delete this note?</string>
+    <string name="your_note_is_deleted">Your note: %s is deleted now.</string>
 </resources>


### PR DESCRIPTION
- When user presses delete action on the app bar, it shows a confirmation dialog.
- If the user confirmst, it triggers a delete note API request:
    - If the request succeeds it goes back to note list and updates the list and also shows a Toast:
    `Your note: $noteTitle is deleted now.`
    - If the request fails, shows a snackbar