### PR TITLE
Handle expired jwt token

### DIFF
--- a/app/src/main/java/com/example/cactusnotes/notes/NotesListActivity.kt
+++ b/app/src/main/java/com/example/cactusnotes/notes/NotesListActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
@@ -19,6 +20,7 @@ import com.google.android.material.snackbar.Snackbar
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+
 
 class NotesListActivity : AppCompatActivity() {
 
@@ -82,6 +84,7 @@ class NotesListActivity : AppCompatActivity() {
             ) {
                 when (response.code()) {
                     200 -> onSuccessfulResponse(response.body()!!)
+                    401, 403 -> onTokenExpired()
                 }
             }
 
@@ -89,7 +92,14 @@ class NotesListActivity : AppCompatActivity() {
                 updateUI(ERROR)
             }
         })
+    }
 
+    private fun onTokenExpired() {
+
+        Snackbar.make(binding.root, R.string.you_need_login, Snackbar.LENGTH_LONG)
+            .setAction("Log in", View.OnClickListener(navigateToLogin())).show()
+        store.deleteJwt()
+        finish()
     }
 
     private fun onSuccessfulResponse(noteListResponse: List<NoteResponse>) {

--- a/app/src/main/java/com/example/cactusnotes/notes/NotesListActivity.kt
+++ b/app/src/main/java/com/example/cactusnotes/notes/NotesListActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.view.View
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
@@ -95,11 +94,14 @@ class NotesListActivity : AppCompatActivity() {
     }
 
     private fun onTokenExpired() {
-
-        Snackbar.make(binding.root, R.string.you_need_login, Snackbar.LENGTH_LONG)
-            .setAction("Log in", View.OnClickListener(navigateToLogin())).show()
-        store.deleteJwt()
-        finish()
+        Snackbar
+            .make(binding.root, R.string.you_need_login, Snackbar.LENGTH_LONG)
+            .setAction(R.string.log_in) {
+                navigateToLogin()
+                store.deleteJwt()
+                finish()
+            }
+            .show()
     }
 
     private fun onSuccessfulResponse(noteListResponse: List<NoteResponse>) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,5 @@
     <string name="share">Share</string>
     <string name="this_action_is_irreversible">This action is irreversable. Are you sure you want to delete this note?</string>
     <string name="your_note_is_deleted">Your note: %s is deleted now.</string>
+    <string name="you_need_login">You need to log in again</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-beta05'
+        classpath 'com.android.tools.build:gradle:7.0.0-rc01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Handles expired token when fetching notes in NoteListActivity.

Shows a snackbar with "Log in" action if the response from fetchNotes() call is either 401 or 403.

Clicking login action deletes JWT and navigates user to the login screen.